### PR TITLE
add query param cache remove to fix view counter issue not increase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # FeedbackR
 
-![ViewCount](https://views.whatilearened.today/views/github/shashankkatte/feedbackr-mern.svg)
+![ViewCount](https://views.whatilearened.today/views/github/shashankkatte/feedbackr-mern.svg?cache=remove)
 [![Contributions Welcome](https://img.shields.io/badge/Contributions-welcome-success.svg?style=flat-square)](./CONTRIBUTING.md)
 [![first-timers-only Friendly](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Contribute%20To%20This%20Project.%20An%20Open-Source%20project%20MERN%20stack.%20By%20@shashankkatte&url=https://github.com/shashankkatte/feedbackr-mern&hashtags=100DaysofCode 'Tweet this project')


### PR DESCRIPTION
# Description
There is a cache in view counter, that's why counter is not increment as expected, to fix this need to send query param `cache=remove`, this will remove cache for view counter, not sure why if `cache` param is not send view counter is stuck

Fixes # (issue)
[Issue #21](https://github.com/shashankkatte/feedbackr-mern/issues/21) View counter is stuck and not increment

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature 
- [ ] Documentation
- [ ] Other - Explain

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I had epic fun with this PR and learnt something new!
